### PR TITLE
flexParameter bug in flex sensor

### DIFF
--- a/sonar-flex-plugin/src/main/java/org/sonar/plugins/flex/flexpmd/FlexPmdSensor.java
+++ b/sonar-flex-plugin/src/main/java/org/sonar/plugins/flex/flexpmd/FlexPmdSensor.java
@@ -80,7 +80,7 @@ public class FlexPmdSensor implements Sensor {
     File workDir = new File(project.getFileSystem().getSonarWorkingDirectory(), "flexpmd");
     prepareWorkDir(workDir);
     List<File> sourceDirs = project.getFileSystem().getSourceDirs();
-    FlexPmdParameters parameters = new FlexPmdParameters("", workDir, rules, null, sourceDirs);
+    FlexPmdParameters parameters = new FlexPmdParameters("", workDir, rules, sourceDirs.get(0), sourceDirs);
     FlexPmdViolations violations = new FlexPmdViolations();
     new FlexPmdXmlEngine(parameters).executeReport(violations);
 


### PR DESCRIPTION
i think "source" variable  is not processed correctly in FileUtil.java when the source is null. The package name will be empty which lead to a wrong files that computed by computeFilesList() and then return a wrong List of Files with full path name instead of the "package+classname". And it will be reporting false positive violation when using "UnboundedTypeMetaData" which uses this list.
