### PR TITLE
Update SSLR to 1.22

### DIFF
--- a/flex-squid/pom.xml
+++ b/flex-squid/pom.xml
@@ -31,6 +31,11 @@
       <artifactId>sslr-squid-bridge</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>10.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
     <sonar.version>5.6</sonar.version>
-    <sslr.version>1.21</sslr.version>
+    <sslr.version>1.22</sslr.version>
     <logback.version>1.0.13</logback.version>
     <junit.version>4.12</junit.version>
     <fest.version>1.4</fest.version>


### PR DESCRIPTION
Also adds explicit dependency on Guava, because SSLR doesn't depend on
Guava anymore, while this project depends.