### PR TITLE
Update release.yml to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,43 +5,43 @@ on:
     types:
       - published
 
-env:
-  PYTHONUNBUFFERED: 1
-
 jobs:
-  sonar_release:
+  release:
     runs-on: ubuntu-latest
-    name: Start release process
+    name: Release
     steps:
-      - name: LT release
-        id: lt_release
+      - name: Configure AWS Credentials # Required for pushing the binaries
+        uses: aws-actions/configure-aws-credentials@v1
         with:
-          distribute: true
+          aws-access-key-id: ${{ secrets.BINARIES_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BINARIES_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.BINARIES_AWS_REGION }}
+      - name: Release
+        id: release
+        uses: SonarSource/gh-action_release/main@v4
+        with:
           publish_to_binaries: true
-          slack_channel: vb6-pli-flex
         env:
           ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
+          BINARIES_AWS_DEPLOY: ${{ secrets.BINARIES_AWS_DEPLOY }}
           BURGRX_USER: ${{ secrets.BURGRX_USER }}
           BURGRX_PASSWORD: ${{ secrets.BURGRX_PASSWORD }}
-          CIRRUS_TOKEN: ${{ secrets.CIRRUS_TOKEN }}
-          PATH_PREFIX: ${{ secrets.BINARIES_PATH_PREFIX }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-          RELEASE_SSH_USER: ${{ secrets.RELEASE_SSH_USER }}
-          RELEASE_SSH_KEY: ${{ secrets.RELEASE_SSH_KEY }}
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN }}
-        # Put your action repo here
-        uses: SonarSource/gh-action_release/main@v3
 
       - name: Release action results
         if: always()
         run: |
-          echo "${{ steps.lt_release.outputs.releasability }}"
-          echo "${{ steps.lt_release.outputs.release }}"
+          echo "${{ steps.release.outputs.releasability }}"
+          echo "${{ steps.release.outputs.promote }}"
+          echo "${{ steps.release.outputs.publish_to_binaries }}"
+          echo "${{ steps.release.outputs.release }}"
 
   maven-central-sync:
     runs-on: ubuntu-latest
+    name: Maven Central Sync
     needs:
-      - sonar_release
+      - release
     steps:
       - name: Setup JFrog CLI
         uses: jfrog/setup-jfrog-cli@v1
@@ -58,14 +58,14 @@ jobs:
         id: local_repo
         run: echo ::set-output name=dir::"$(mktemp -d repo.XXXXXXXX)"
       - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@v3
+        uses: SonarSource/gh-action_release/download-build@v4
         with:
           build-number: ${{ steps.get_version.outputs.build }}
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
       - name: Maven Central Sync
         id: maven-central-sync
         continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@v3
+        uses: SonarSource/gh-action_release/maven-central-sync@v4
         with:
           local-repo-dir: ${{ steps.local_repo.outputs.dir }}
         env:
@@ -75,6 +75,7 @@ jobs:
         if: ${{ failure() || steps.maven-central-sync.outcome == 'failure' }}
         uses: 8398a7/action-slack@v3
         with:
+          text: 'Maven sync failed'
           status: failure
           fields: repo,author,eventName
         env:


### PR DESCRIPTION
Synchronize the release.yml with current version of the release script:
https://github.com/SonarSource/gh-action_release#full-example

We've created a dedicated `#team-lang-vb6` so we need to archive the old `#vb6-pli-flex` slack channel.

Please let me know in case you'll create a channel for flex, I can update this PR with the name.