### PR TITLE
SONARFLEX-195 Fix discrepancies between MQR and severity for Flex rules

### DIFF
--- a/flex-checks/pom.xml
+++ b/flex-checks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.flex</groupId>
     <artifactId>flex</artifactId>
-    <version>2.15.0-SNAPSHOT</version>
+    <version>2.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>flex-checks</artifactId>

--- a/flex-checks/src/main/resources/org/sonar/l10n/flex/rules/flex/ClassComplexity.json
+++ b/flex-checks/src/main/resources/org/sonar/l10n/flex/rules/flex/ClassComplexity.json
@@ -8,7 +8,9 @@
     "linearOffset": "10min",
     "linearFactor": "1min"
   },
-  "tags": [],
+  "tags": [
+    "brain-overload"
+  ],
   "defaultSeverity": "Critical",
   "ruleSpecification": "RSPEC-1311",
   "sqKey": "S1311",

--- a/flex-checks/src/main/resources/org/sonar/l10n/flex/rules/flex/S1451.json
+++ b/flex-checks/src/main/resources/org/sonar/l10n/flex/rules/flex/S1451.json
@@ -12,7 +12,9 @@
     "func": "Constant\/Issue",
     "constantCost": "5min"
   },
-  "tags": [],
+  "tags": [
+    "convention"
+  ],
   "defaultSeverity": "Blocker",
   "ruleSpecification": "RSPEC-1451",
   "sqKey": "S1451",

--- a/flex-squid/pom.xml
+++ b/flex-squid/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.flex</groupId>
     <artifactId>flex</artifactId>
-    <version>2.15.0-SNAPSHOT</version>
+    <version>2.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>flex-squid</artifactId>

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.flex</groupId>
     <artifactId>flex-its</artifactId>
-    <version>2.15.0-SNAPSHOT</version>
+    <version>2.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>it-flex</artifactId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.flex</groupId>
     <artifactId>flex</artifactId>
-    <version>2.15.0-SNAPSHOT</version>
+    <version>2.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>flex-its</artifactId>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.flex</groupId>
     <artifactId>flex-its</artifactId>
-    <version>2.15.0-SNAPSHOT</version>
+    <version>2.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>it-flex-ruling</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.sonarsource.flex</groupId>
   <artifactId>flex</artifactId>
-  <version>2.15.0-SNAPSHOT</version>
+  <version>2.14.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Flex</name>

--- a/sonar-flex-plugin/pom.xml
+++ b/sonar-flex-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.flex</groupId>
     <artifactId>flex</artifactId>
-    <version>2.15.0-SNAPSHOT</version>
+    <version>2.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-flex-plugin</artifactId>

--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "FLEX"
   ],
-  "latest-update": "2024-11-25T11:36:05.186615Z",
+  "latest-update": "2025-02-24T15:51:52.474746700Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": true

--- a/sslr-flex-toolkit/pom.xml
+++ b/sslr-flex-toolkit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.flex</groupId>
     <artifactId>flex</artifactId>
-    <version>2.15.0-SNAPSHOT</version>
+    <version>2.14.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sslr-flex-toolkit</artifactId>


### PR DESCRIPTION
[SONARFLEX-195](https://sonarsource.atlassian.net/browse/SONARFLEX-195)

seems we can ignore sonar-flex. does not look like any severity changed. wdyt @kebetsi?

[SONARFLEX-195]: https://sonarsource.atlassian.net/browse/SONARFLEX-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ