### PR TITLE
Revert "SONARFLEX-198 GitHub workflows migration to self hosted runners (#205)"

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: read


### PR DESCRIPTION
[SONARFLEX-198](https://sonarsource.atlassian.net/browse/SONARFLEX-198)

This reverts commit dcc0c7faea9a042bbefdc57844822eb38c229023.

Self hosted runners should not be used on public repositories. Sonar-runner is only for [private and internal repositories](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3694231566/Using+Self-Hosted+GitHub+Runners+-+GitHub#1.-Repository-access-to-the-runner).


[SONARFLEX-198]: https://sonarsource.atlassian.net/browse/SONARFLEX-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ