### PR TITLE
SONARFLEX-199 Use "sonar.scanner.skipJreProvisioning" in integration tests

### DIFF
--- a/its/plugin/src/test/java/com/sonar/it/flex/Tests.java
+++ b/its/plugin/src/test/java/com/sonar/it/flex/Tests.java
@@ -54,11 +54,13 @@ public class Tests {
     .build();
 
   public static MavenBuild createMavenBuild() {
-    return MavenBuild.create();
+    return MavenBuild.create()
+      .setProperty("sonar.scanner.skipJreProvisioning", "true");
   }
 
   public static SonarScanner createSonarScanner() {
-    return SonarScanner.create();
+    return SonarScanner.create()
+      .setProperty("sonar.scanner.skipJreProvisioning", "true");
   }
 
   @CheckForNull

--- a/its/ruling/src/test/java/org/sonar/flex/it/FlexRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/flex/it/FlexRulingTest.java
@@ -46,6 +46,7 @@ public class FlexRulingTest {
     File litsDifferencesFile = FileLocation.of("target/differences").getFile();
 
     SonarScanner build = SonarScanner.create(FileLocation.of("../sources/src").getFile())
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setProjectKey("project")
       .setProjectName("project")
       .setProjectVersion("1")


### PR DESCRIPTION
[SONARFLEX-199](https://sonarsource.atlassian.net/browse/SONARFLEX-199)

On ephemeral CI machine this avoids unnecessary downloading and unpacking of JRE from SQ and thus reduces time of execution of the first project analysis in integration tests.

During execution of integration tests we already have suitable JDK.

Testing of JRE provisioning feature should not be the responsibility of analyzers.


[SONARFLEX-199]: https://sonarsource.atlassian.net/browse/SONARFLEX-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ