### PR TITLE
SONARFLEX-224 Restore release.yml without GH release publish trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+---
+name: sonar-release
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: Version
+        required: true
+      releaseId:
+        type: string
+        description: Release ID
+        required: true
+      dryRun:
+        type: boolean
+        description: Flag to enable the dry-run execution
+        default: false
+        required: false
+
+jobs:
+  release:
+    permissions:
+      id-token: write
+      contents: write
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
+    with:
+      version: ${{ inputs.version }}
+      releaseId: ${{ inputs.releaseId }}
+      dryRun: ${{ inputs.dryRun || false }}
+      publishToBinaries: true
+      mavenCentralSync: true
+      slackChannel: ask-squad-web


### PR DESCRIPTION
## Summary
- Restores `.github/workflows/release.yml` that was deleted in #314
- Removes the `release: published` trigger, keeping only `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)