### PR TITLE
SONARFLEX-225 Configure Renovate immediate PR creation and disable grouping by default

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,12 @@
   ],
   "packageRules": [
     {
+      "description": "Group npm and maven updates per source repository (monorepo), fallback to per dependency",
+      "matchManagers": ["npm", "maven"],
+      "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
+      "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
+    },
+    {
       "matchManagers": ["github-actions"],
       "pinDigests": false,
       "groupName": "all github actions",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,5 +32,6 @@
     }
   ],
   "autoApprove": true,
+  "prCreation": "immediate",
   "rebaseWhen": "never"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,15 +12,13 @@
   ],
   "packageRules": [
     {
-      "description": "Don't group maven updates",
-      "matchManagers": ["maven"],
+      "description": "Don't group updates by default",
+      "matchPackageNames": ["*"],
       "groupName": null
     },
     {
       "matchManagers": ["github-actions"],
-      "pinDigests": false,
-      "groupName": "all github actions",
-      "groupSlug": "all-github-actions"
+      "pinDigests": false
     },
     {
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,11 @@
   ],
   "packageRules": [
     {
+      "description": "Don't group maven updates",
+      "matchManagers": ["maven"],
+      "groupName": null
+    },
+    {
       "matchManagers": ["github-actions"],
       "pinDigests": false,
       "groupName": "all github actions",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,12 +12,6 @@
   ],
   "packageRules": [
     {
-      "description": "Group npm and maven updates per source repository (monorepo), fallback to per dependency",
-      "matchManagers": ["npm", "maven"],
-      "groupName": "{{#if sourceRepo}}{{sourceRepo}} monorepo{{else}}{{depName}}{{/if}}",
-      "groupSlug": "{{#if sourceRepo}}{{sourceRepo}}{{else}}{{depName}}{{/if}}"
-    },
-    {
       "matchManagers": ["github-actions"],
       "pinDigests": false,
       "groupName": "all github actions",


### PR DESCRIPTION
## Summary
- set \prCreation\ to \immediate\ in Renovate config
- keeps branch creation and PR creation coupled

## Why
This avoids branch-only updates being left without PRs when checks are pending.