### PR TITLE
CLP-21 Move repository ownership to Core Languages and Parsers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @SonarSource/quality-web-squad
+.github/CODEOWNERS @SonarSource/code-quality-core-languages-parsers-squad

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - &mise
         name: Setup mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Repository configuration:**
  - Update `CODEOWNERS` to transfer repository ownership to the `code-quality-core-languages-parsers-squad` team.
- **CI/CD fixes:**
  - Revert `mise-action` version to `v4.0.1` in `.github/workflows/build.yml` to resolve build issues.

<sub>This will update automatically on new commits.</sub>