### PR TITLE
SONARFLEX-228 fix(ci): revert build mise-action to v4.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - &mise
         name: Setup mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2025.7.12
 


### PR DESCRIPTION
## Summary
Revert the shared build `mise-action` anchor in `.github/workflows/build.yml` to `v4.0.1`.

## Why
The current Windows build fails in `Setup mise` before Maven starts.

`jdx/mise-action@v4.1.0` changed the Windows cache key, which forces a cold `mise install` on `windows-latest`. That cold install tries to resolve Maven through `https://mise-versions.jdx.dev/aqua-registry/apache/maven/registry.yaml`, which is currently returning `400 Bad Request`.

`sonar-html` hit the same regression in `#700` and worked around it in `#701` by reverting the build-path `mise-action` version.

## Scope
This PR keeps the rollback narrow and only changes the shared `build/windows` anchor in `build.yml`. It does not change the separate `bump-versions` workflow.