### PR TITLE
CLP-69 Update notifications Slack channels

### DIFF
--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -25,4 +25,4 @@ jobs:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
           additional-message: ${{ github.event.inputs.additional-message }}
-          slack-channel: squad-corelang-notifs
+          slack-channel: core-languages-releases

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -49,7 +49,7 @@ jobs:
       create-sli-ticket: false
       branch: ${{ github.event.inputs.branch }}
       pm-email: "gabriel.vivas@sonarsource.com"
-      slack-channel: "ask-squad-web"
+      slack-channel: "core-languages-releases"
       release-automation-secret-name: "SonarFlex-release-automation"
       runner-environment: "github-ubuntu-latest-s"
       verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
       dryRun: ${{ inputs.dryRun || false }}
       publishToBinaries: true
       mavenCentralSync: true
-      slackChannel: ask-squad-web
+      slackChannel: core-languages-releases


### PR DESCRIPTION
Part of [CLP-59](https://sonarsource.atlassian.net/browse/CLP-59).

[CLP-59]: https://sonarsource.atlassian.net/browse/CLP-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **Configuration updates:**
  - Redirect Slack notifications to `core-languages-releases` channel in `ToggleLockBranch.yml`, `automated-release.yml`, and `release.yml` workflows.

<sub>This will update automatically on new commits.</sub>