### PR TITLE
CLP-69 Update Slack channel names

### DIFF
--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -25,4 +25,4 @@ jobs:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
           additional-message: ${{ github.event.inputs.additional-message }}
-          slack-channel: core-languages-releases
+          slack-channel: squad-corelang-releases

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -49,7 +49,7 @@ jobs:
       create-sli-ticket: false
       branch: ${{ github.event.inputs.branch }}
       pm-email: "gabriel.vivas@sonarsource.com"
-      slack-channel: "core-languages-releases"
+      slack-channel: "squad-corelang-releases"
       release-automation-secret-name: "SonarFlex-release-automation"
       runner-environment: "github-ubuntu-latest-s"
       verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
       dryRun: ${{ inputs.dryRun || false }}
       publishToBinaries: true
       mavenCentralSync: true
-      slackChannel: core-languages-releases
+      slackChannel: squad-corelang-releases


### PR DESCRIPTION
----
## Summary by Gitar

- **Configuration updates:**
  - Rename Slack notification channels from `core-languages-releases` to `squad-corelang-releases` across `ToggleLockBranch.yml`, `automated-release.yml`, and `release.yml` workflows.

<sub>This will update automatically on new commits.</sub>