### PR TITLE
SONARFLEX-233 Fix automated release workflow permissions

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -29,7 +29,7 @@ jobs:
     name: Release
     uses: SonarSource/release-github-actions/.github/workflows/automated-release.yml@v1
     permissions:
-      statuses: read
+      statuses: write
       id-token: write
       contents: write
       actions: write


### PR DESCRIPTION
## Summary
Fix the `Automated Release` caller workflow to grant `statuses: write` when invoking `SonarSource/release-github-actions/.github/workflows/automated-release.yml@v1`.

## Why
The upstream reusable workflow now includes `set-release-lock` and `clear-release-lock` jobs that request `statuses: write`.
With `statuses: read` in this repository, GitHub rejects the workflow as invalid before the run starts.

## Validation
- Parsed `.github/workflows/automated-release.yml` with Ruby YAML: `YAML OK`
- Ran `git diff --check -- .github/workflows/automated-release.yml`

## Impact
The automated release workflow remains unchanged functionally, but it now has the permission level required by the current reusable release workflow.
