### PR TITLE
Fix release workflow inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,6 @@ on:
         type: string
         description: Version
         required: true
-      releaseId:
-        type: string
-        description: Release ID
-        required: true
       dryRun:
         type: boolean
         description: Flag to enable the dry-run execution
@@ -26,7 +22,6 @@ jobs:
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@0c9c1cc54cbdd24258f135601d1b77cfc87e67ae # 7.4.0
     with:
       version: ${{ inputs.version }}
-      releaseId: ${{ inputs.releaseId }}
       dryRun: ${{ inputs.dryRun || false }}
       publishToBinaries: true
       mavenCentralSync: true


### PR DESCRIPTION
## What changed
This removes the obsolete `releaseId` input from `.github/workflows/release.yml` and stops forwarding it to the reusable `gh-action_release` workflow.

## Why
The pinned reusable workflow no longer accepts `releaseId`, so GitHub rejects the downstream `sonar-release` workflow at startup.

## Impact
This lets the release workflow start normally again after the GitHub release is published.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts \"YAML OK\""`
- `git diff --check -- .github/workflows/release.yml`
