### PR TITLE
SONARFLEX-233: Fix release-automation Vault secret name

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -50,7 +50,7 @@ jobs:
       branch: ${{ github.event.inputs.branch }}
       pm-email: "gabriel.vivas@sonarsource.com"
       slack-channel: "squad-corelang-releases"
-      release-automation-secret-name: "SonarFlex-release-automation"
+      release-automation-secret-name: "sonar-flex-release-automation"
       runner-environment: "github-ubuntu-latest-s"
       verbose: true
       use-jira-sandbox: false


### PR DESCRIPTION
SONARFLEX-233: Align the Automated Release workflow with the `release-automation` secret that is actually provisioned in Vault.

## Problem
The `Update analyzer in Analysis as a Service` and `Update analyzers in SQS and SQC` jobs failed with `403 Forbidden` (Vault `DENIED`). The reusable action builds the Vault path as `development/github/token/SonarSource-<release-automation-secret-name>`, and the workflow passed `SonarFlex-release-automation`, producing `.../SonarSource-SonarFlex-release-automation` — a path that does not exist in Vault.

## Fix
The secret is provisioned in `re-terraform-aws-vault` (`orders/analysis-js-squad.yaml`) as `sonar-flex-release-automation`, matching the repo slug and the reusable workflow's documented default. This changes the input to `sonar-flex-release-automation` so the jobs request the existing, granted path (write access to `sonar-enterprise`, `sonarcloud-core`, `sonar-plugins-deployer`, `sonar-analysis-as-a-service`).

## Validation
- Verified against the Terraform source of truth that the conventional path exists and is granted to exactly the deployment targets these jobs push to.
- Every peer analyzer (`sonar-php`, `sonar-html`, `sonar-rust`, …) uses the same `sonar-<plugin>-release-automation` convention.

No functional change beyond the secret name; no new inputs or breaking changes.