### PR TITLE
CLP-139 Clean up Renovate config in sonar-flex

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,13 +3,6 @@
   "extends": [
     "local>SonarSource/core-languages-tooling-public:renovate-config"
   ],
-  "enabledManagers": [
-    "github-actions",
-    "maven"
-  ],
-  "dockerfile": {
-    "enabled": true
-  },
   "ignorePaths": [
     "its/sources/**",
     "its/plugin/projects/**"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,22 +9,6 @@
   ],
   "packageRules": [
     {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "pinDigests": false
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "pin",
-        "rollback"
-      ],
-      "enabled": false
-    },
-    {
       "matchPackageNames": [
         "org.sonarsource.flex:flex-its"
       ],


### PR DESCRIPTION
Part of CLP-11.

This PR cleans up the local Renovate config after the latest updates in the squad parent preset.

Expected current effective delta:
- track `mise.toml` updates
- pin third-party GitHub Actions to commit SHAs
- allow rollback PRs for third-party GitHub Actions
