### PR TITLE
CLP-212: Migrate scanner test fixtures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,6 @@
       </dependency>
       <dependency>
         <groupId>org.sonarsource.sonarqube</groupId>
-        <artifactId>sonar-plugin-api-impl</artifactId>
-        <version>${sonar.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.sonarsource.sonarqube</groupId>
         <artifactId>sonar-testing-harness</artifactId>
         <version>${sonar.version}</version>
       </dependency>

--- a/sonar-flex-plugin/pom.xml
+++ b/sonar-flex-plugin/pom.xml
@@ -36,11 +36,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api-impl</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>flex-squid</artifactId>
     </dependency>

--- a/sonar-flex-plugin/src/test/java/org/sonar/plugins/flex/FlexPluginTest.java
+++ b/sonar-flex-plugin/src/test/java/org/sonar/plugins/flex/FlexPluginTest.java
@@ -16,12 +16,12 @@
  */
 package org.sonar.plugins.flex;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.Plugin;
 import org.sonar.api.SonarEdition;
 import org.sonar.api.SonarQubeSide;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.utils.Version;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +30,7 @@ public class FlexPluginTest {
 
   @Test
   public void testGetExtensions() throws Exception {
-    SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarQube(Version.create(7, 9), SonarQubeSide.SCANNER, SonarEdition.DEVELOPER);
+    SonarRuntime sonarRuntime = TestSonarRuntime.forSonarQube(Version.create(7, 9), SonarQubeSide.SCANNER, SonarEdition.DEVELOPER);
     Plugin.Context context = new Plugin.Context(sonarRuntime);
     new FlexPlugin().define(context);
     assertThat(context.getExtensions()).isNotEmpty();

--- a/sonar-flex-plugin/src/test/java/org/sonar/plugins/flex/FlexRulesDefinitionTest.java
+++ b/sonar-flex-plugin/src/test/java/org/sonar/plugins/flex/FlexRulesDefinitionTest.java
@@ -16,11 +16,11 @@
  */
 package org.sonar.plugins.flex;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarRuntime;
-import org.sonar.api.internal.SonarRuntimeImpl;
-import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinition.Rule;
+import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.utils.Version;
 import org.sonar.flex.checks.CheckList;
 
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FlexRulesDefinitionTest {
 
-  private static final SonarRuntime sonarRuntime = SonarRuntimeImpl.forSonarLint(Version.create(9, 3));
+  private static final SonarRuntime sonarRuntime = TestSonarRuntime.forSonarLint(Version.create(9, 3));
 
   @Test
   public void test() {

--- a/sonar-flex-plugin/src/test/java/org/sonar/plugins/flex/FlexSquidSensorTest.java
+++ b/sonar-flex-plugin/src/test/java/org/sonar/plugins/flex/FlexSquidSensorTest.java
@@ -16,6 +16,9 @@
  */
 package org.sonar.plugins.flex;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestSonarRuntime;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -32,7 +35,6 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.highlighting.TypeOfText;
-import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.FileLinesContext;
 import org.sonar.api.measures.FileLinesContextFactory;
@@ -47,9 +49,6 @@ import org.sonar.scanner.plugin.api.impl.rule.ActiveRulesBuilder;
 import org.sonar.scanner.plugin.api.impl.rule.NewActiveRule;
 import org.sonar.scanner.plugin.api.impl.sensor.DefaultSensorDescriptor;
 
-import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
-import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -59,7 +58,7 @@ import static org.mockito.Mockito.when;
 public class FlexSquidSensorTest {
 
   private static final File TEST_DIR = new File("src/test/resources/org/sonar/plugins/flex/squid");
-  private static final SonarRuntime SONARQUBE_89 = SonarRuntimeImpl.forSonarQube(Version.create(8, 9), SonarQubeSide.SCANNER, SonarEdition.DEVELOPER);
+  private static final SonarRuntime SONARQUBE_89 = TestSonarRuntime.forSonarQube(Version.create(8, 9), SonarQubeSide.SCANNER, SonarEdition.DEVELOPER);
 
   private FlexSquidSensor sensor;
   private SensorContextTester tester;
@@ -180,7 +179,7 @@ public class FlexSquidSensorTest {
   @Test
   public void test_descriptor_sonarlint() {
     DefaultSensorDescriptor descriptor = new DefaultSensorDescriptor();
-    createSensor(SonarRuntimeImpl.forSonarLint(Version.create(6, 5))).describe(descriptor);
+    createSensor(TestSonarRuntime.forSonarLint(Version.create(6, 5))).describe(descriptor);
     assertThat(descriptor.name()).isEqualTo("Flex");
     assertThat(descriptor.languages()).containsOnly("flex");
   }
@@ -189,7 +188,7 @@ public class FlexSquidSensorTest {
   public void test_descriptor_sonarqube_9_3() {
     DefaultSensorDescriptor descriptor = spy(new DefaultSensorDescriptor());
     when(descriptor.processesFilesIndependently()).thenReturn(descriptor);
-    createSensor(SonarRuntimeImpl.forSonarQube(Version.create(9, 3), SonarQubeSide.SCANNER, SonarEdition.DEVELOPER)).describe(descriptor);
+    createSensor(TestSonarRuntime.forSonarQube(Version.create(9, 3), SonarQubeSide.SCANNER, SonarEdition.DEVELOPER)).describe(descriptor);
     assertThat(descriptor.name()).isEqualTo("Flex");
     assertThat(descriptor.languages()).containsOnly("flex");
     verify(descriptor).processesFilesIndependently();

--- a/sonar-flex-plugin/src/test/java/org/sonar/plugins/flex/core/FlexTest.java
+++ b/sonar-flex-plugin/src/test/java/org/sonar/plugins/flex/core/FlexTest.java
@@ -18,9 +18,9 @@ package org.sonar.plugins.flex.core;
 
 import org.junit.jupiter.api.Test;
 import org.sonar.api.config.Configuration;
-import org.sonar.api.config.internal.ConfigurationBridge;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.plugins.flex.FlexPlugin;
+import org.sonar.scanner.plugin.api.impl.config.ConfigurationBridge;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
## Summary

- remove the SonarQube `sonar-plugin-api-impl` dependency
- migrate moved scanner implementation imports and use `TestSonarRuntime`
- keep the existing scanner-engine 13.4.1 fixture dependencies as the test baseline

## Dependency changes

Before: the plugin resolved both the old SonarQube implementation artifact and the scanner fixtures.

After: tests use `plugin-api-scanner-impl` and `sensor-test-fixtures` at `13.4.1.4007`; the resolved Maven graph contains no `sonar-plugin-api-impl`.

`sonar-plugin-api-test-fixtures` is retained for its logging helpers.

## Validation

- `mvn -q test`
- Maven dependency-tree check for `org.sonarsource.sonarqube:sonar-plugin-api-impl` (no matches)
- `git diff --check`
